### PR TITLE
Change region_name to None if empty string

### DIFF
--- a/skew/awsclient.py
+++ b/skew/awsclient.py
@@ -136,4 +136,6 @@ class AWSClient(object):
 
 
 def get_awsclient(service_name, region_name, account_id, **kwargs):
+    if region_name == '':
+        region_name = None
     return AWSClient(service_name, region_name, account_id, **kwargs)


### PR DESCRIPTION
Botocore checks for None as opposed to empty string and will not generate endpoints properly for global services when an empty string is passed.
