### PR TITLE
Fix ARNs for CloudWatch alarms

### DIFF
--- a/skew/resources/aws/cloudwatch.py
+++ b/skew/resources/aws/cloudwatch.py
@@ -28,3 +28,12 @@ class Alarm(AWSResource):
         name = 'AlarmName'
         date = 'AlarmConfigurationUpdatedTimestamp'
         dimension = None
+
+    @property
+    def arn(self):
+        return 'arn:aws:%s:%s:%s:%s:%s' % (
+            self._client.service_name,
+            self._client.region_name,
+            self._client.account_id,
+            self.resourcetype,
+            self.data['AlarmName'])


### PR DESCRIPTION
Before: `arn:aws:cloudwatch:us-east-1:123456789012:alarm:arn:aws:cloudwatch:us-east-1:123456789012:alarm:db-table-ReadCapacityUnitsLimit-BasicAlarm`

After: `arn:aws:cloudwatch:us-east-1:123456789012:alarm:db-table-ReadCapacityUnitsLimit-BasicAlarm`
