### PR TITLE
Handle s3 SlowDown throttle messages

### DIFF
--- a/skew/awsclient.py
+++ b/skew/awsclient.py
@@ -127,7 +127,8 @@ class AWSClient(object):
                     done = True
                 except ClientError as e:
                     LOG.debug(e, kwargs)
-                    if 'Throttling' in str(e):
+                    back_off_errors = ['(Throttling)', '(SlowDown)']
+                    if any(i in str(e) for i in back_off_errors):
                         time.sleep(1)
                     elif 'AccessDenied' in str(e):
                         done = True


### PR DESCRIPTION
The current throttling sleep only looks for the message "Throttling" - however, S3 can also return this ClientError:
```
ClientError: An error occurred (SlowDown) when calling the GetBucketLocation operation (reached max retries: 4): Please reduce your request rate.
```
Which will not match and thus skew will raise the error instead of retrying.